### PR TITLE
test: fill in missing adapter tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,15 @@ hero:
   tagline: keep your chocolate out of my peanut butter
   actions:
     - text: Get Started
-      link: /guides/installation
+      link: guides/installation
       icon: right-arrow
     - text: See the transforms
-      link: /guides/gfm-components-test
+      link: guides/gfm-components-test
       variant: minimal
+    - text: LLMs.txt
+      link: llms.txt
+      variant: secondary
+      icon: document
+      attrs:
+        iconPlacement: start
 ---

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,6 +6,7 @@ import githubAlerts from "./src/integrations/github-alerts/index.js";
 import rehypeGithubEmoji from 'rehype-github-emoji';
 import { rehypeGfmComponents } from "rehype-gfm-components";
 import starlightGfmComponents from "rehype-gfm-components/starlight";
+import rehypeBasePath from "./src/plugins/rehype-base-path.js";
 
 // https://astro.build/config
 export default defineConfig({
@@ -15,7 +16,7 @@ export default defineConfig({
     defaultStrategy: 'viewport'
   },
   markdown: {
-    rehypePlugins: [rehypeGithubEmoji, rehypeGfmComponents],
+    rehypePlugins: [rehypeGithubEmoji, rehypeGfmComponents, [rehypeBasePath, "/rehype-gfm-components"]],
   },
   integrations: [
     starlight({

--- a/site/src/plugins/rehype-base-path.js
+++ b/site/src/plugins/rehype-base-path.js
@@ -1,0 +1,21 @@
+/**
+ * Rehype plugin that prepends the site's base path to absolute internal links.
+ * Fixes the classic static-site base path problem in one spot.
+ */
+import { visit } from "unist-util-visit";
+
+export default function rehypeBasePath(base = "/") {
+  const prefix = base.replace(/\/$/, "");
+  if (!prefix) return () => {};
+
+  return (tree) => {
+    visit(tree, "element", (node) => {
+      if (node.tagName === "a" && typeof node.properties?.href === "string") {
+        const href = node.properties.href;
+        if (href.startsWith("/") && !href.startsWith("//") && !href.startsWith(prefix)) {
+          node.properties.href = prefix + href;
+        }
+      }
+    });
+  };
+}

--- a/test/adapter.test.js
+++ b/test/adapter.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import starlightGfmComponents from "../adapters/starlight.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..");
+
+describe("Starlight adapter", () => {
+  it("returns an Astro integration with the correct name", () => {
+    const integration = starlightGfmComponents();
+    expect(integration.name).toBe("rehype-gfm-components");
+    expect(integration.hooks).toBeDefined();
+    expect(integration.hooks["astro:config:setup"]).toBeTypeOf("function");
+  });
+
+  it("injects CSS and tab script via astro:config:setup", () => {
+    const integration = starlightGfmComponents();
+    const injectScript = vi.fn();
+
+    integration.hooks["astro:config:setup"]({ injectScript });
+
+    expect(injectScript).toHaveBeenCalledTimes(2);
+
+    // First call: page-ssr CSS import
+    const [ssrContext, ssrPayload] = injectScript.mock.calls[0];
+    expect(ssrContext).toBe("page-ssr");
+    expect(ssrPayload).toContain("starlight.css");
+    expect(ssrPayload).toMatch(/^import /);
+
+    // Second call: page tab script
+    const [pageContext, pagePayload] = injectScript.mock.calls[1];
+    expect(pageContext).toBe("page");
+
+    // Verify it's actually the tabs script content
+    const expectedScript = readFileSync(
+      join(rootDir, "scripts", "tabs.js"),
+      "utf-8"
+    );
+    expect(pagePayload).toBe(expectedScript);
+  });
+
+  it("CSS path resolves to an existing file", () => {
+    const integration = starlightGfmComponents();
+    const injectScript = vi.fn();
+
+    integration.hooks["astro:config:setup"]({ injectScript });
+
+    const ssrPayload = injectScript.mock.calls[0][1];
+    // Extract the path from: import "/absolute/path/to/starlight.css";
+    const match = ssrPayload.match(/import "(.+)"/);
+    expect(match).not.toBeNull();
+
+    // Should not throw
+    const css = readFileSync(match[1], "utf-8");
+    expect(css.length).toBeGreaterThan(0);
+  });
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -157,6 +157,14 @@ This feature is \`New\`<!-- badge variant:tip --> and ready.
     expect(html).not.toContain("starlight-tabs");
   });
 
+  it("disables tooltips when tooltips: false", async () => {
+    const md = `Astro[^1] is great.\n\n[^1]: A web framework.`;
+    const html = await process(md, { tooltips: false });
+    // Footnote should remain as a standard GFM footnote link, not a tooltip
+    expect(html).not.toContain("data-gfm-tooltip");
+    expect(html).toContain("data-footnote-ref");
+  });
+
   it("wraps accordiongroup details in a grouping div", async () => {
     const md = [
       "<!-- accordiongroup -->",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,7 +10,6 @@ export default defineConfig({
         "transforms/**",
         "lib/**",
         "adapters/**",
-        "scripts/**",
       ],
       reporter: ["text", "lcov"],
     },


### PR DESCRIPTION
- Rehype plugin to prepend base path to absolute internal links in content
- Adapter test suite (3 tests) — starlight.js 0% → 100% coverage
- tooltips: false option test
- Exclude client-side tabs script from Node coverage scope