### PR TITLE
chore: format llms.txt and llms-full.txt with npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/krypton
+          registry-url: https://registry.npmjs.org
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          cache: true
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm vitest run
+
+      - name: Publish with provenance
+        run: pnpm publish --access public --provenance --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/guides/gfm-components-test.md
+++ b/docs/guides/gfm-components-test.md
@@ -1,5 +1,5 @@
 ---
-title: GFM Components Test
+title: All-the-Things Demo
 description: Testing all rehype-gfm-components transforms
 ---
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,6 +1,8 @@
 ---
 title: Installation
 description: How to install and configure rehype-gfm-components
+sidebar:
+  order: 1
 ---
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
   "bugs": {
     "url": "https://github.com/claylo/rehype-gfm-components/issues"
   },
-  "homepage": "https://github.com/claylo/rehype-gfm-components#readme",
+  "homepage": "https://claylo.github.io/rehype-gfm-components",
+  "llms": {
+    "tagline": "Write GFM. View it on GitHub. Deploy it with Starlight. The same Markdown file works in both places — readable on GitHub, rich and interactive in Starlight. No MDX. No imports. No JSX.",
+    "sections": ["guides", "components", "plans"]
+  },
   "exports": {
     ".": "./index.js",
     "./starlight": "./adapters/starlight.js",

--- a/site/src/pages/llms-full.txt.ts
+++ b/site/src/pages/llms-full.txt.ts
@@ -11,9 +11,9 @@ const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8"));
 const repoUrl = (pkg.repository?.url ?? pkg.repository ?? "")
   .replace(/^git\+/, "")
   .replace(/\.git$/, "");
-const rawRepoUrl = repoUrl.replace("github.com", "raw.githubusercontent.com") + "/main";
+const GITHUB_RAW = repoUrl.replace("github.com", "raw.githubusercontent.com") + "/main";
 
-type Doc = { id: string; data: { title?: string; description?: string } };
+type Doc = { id: string; data: { title?: string; description?: string }; body?: string };
 
 function baseUrl(site: URL | undefined): string {
   const origin = site?.href.replace(/\/$/, "") ?? "";
@@ -21,7 +21,14 @@ function baseUrl(site: URL | undefined): string {
   return `${origin}${base}`;
 }
 
-/** Group docs by first path segment, ordered by llms.sections from package.json. */
+function resolveScreenshots(content: string): string {
+  return content.replace(
+    /!\[([^\]]*)\]\((docs\/assets\/[^)]+)\)/g,
+    (_, alt, path) => `![${alt}](${GITHUB_RAW}/${path})`
+  );
+}
+
+/** Group docs by first path segment, ordered by llms.sections from package.json. Full body included. */
 function buildSections(docs: Doc[], siteBase: string): string[] {
   const groups = new Map<string, { heading: string; entries: Doc[] }>();
 
@@ -43,7 +50,6 @@ function buildSections(docs: Doc[], siteBase: string): string[] {
     }
   }
 
-  // Order sections by llms.sections, append any unlisted sections at the end
   const order: string[] = pkg.llms?.sections ?? [];
   const sorted = [
     ...order.filter((s: string) => groups.has(s)),
@@ -53,14 +59,14 @@ function buildSections(docs: Doc[], siteBase: string): string[] {
   const lines: string[] = [];
   for (const key of sorted) {
     const { heading, entries } = groups.get(key)!;
-    lines.push(`## ${heading}`, "");
+    lines.push("---", "", `## ${heading}`, "");
     for (const doc of entries.sort((a, b) => (a.data.title ?? a.id).localeCompare(b.data.title ?? b.id))) {
       const url = `${siteBase}/${doc.id}/`;
       const title = doc.data.title ?? doc.id;
-      const desc = doc.data.description ?? "";
-      lines.push(desc ? `- [${title}](${url}): ${desc}` : `- [${title}](${url})`);
+      const desc = doc.data.description ? `\n> ${doc.data.description}` : "";
+      const body = doc.body?.trim() ?? "";
+      lines.push(`### [${title}](${url})${desc}`, "", body, "");
     }
-    lines.push("");
   }
 
   return lines;
@@ -70,15 +76,24 @@ export const GET: APIRoute = async ({ site }) => {
   const docs = await getCollection("docs");
   const siteBase = baseUrl(site);
 
+  const readme = readFileSync(join(repoRoot, "README.md"), "utf-8");
+  const resolvedReadme = resolveScreenshots(readme);
+
   const lines: string[] = [
-    `# ${pkg.name}`,
+    `# ${pkg.name} — Full Documentation`,
     "",
     `> ${pkg.llms?.tagline ?? pkg.description}`,
     "",
-    `- [Full documentation](${siteBase}/llms-full.txt)`,
-    `- [Project README](${rawRepoUrl}/README.md)`,
+    `- [Project README](${GITHUB_RAW}/README.md)`,
     `- [Source](${repoUrl})`,
     `- [npm](https://www.npmjs.com/package/${pkg.name})`,
+    `- [Documentation](${siteBase}/)`,
+    "",
+    "---",
+    "",
+    "## README",
+    "",
+    resolvedReadme,
     "",
     ...buildSections(docs, siteBase),
   ];


### PR DESCRIPTION
Dynamic llms.txt and llms-full.txt endpoints derived entirely from
package.json and the content collection — no hardcoded project names,
URLs, section names, or taglines buried in source files.
- llms.txt: sectioned index with links to full docs, raw README, source, npm
- llms-full.txt: complete doc content inline with resolved screenshot URLs
- Sections grouped by content directory, ordered via llms.sections in package.json
- Section headings pulled from each directory's README title
- Repo URL, raw URL, and npm link all derived from package.json repository field
- Tagline from package.json llms.tagline, falls back to description
- GitHub Actions publish workflow with provenance via OIDC (Node lts/krypton)